### PR TITLE
Web site updates across multiple pages

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,16 @@ editLink: true
 
 </center>
 
+::: tip
+ODG gave an overview presentation on the project and our use of the 
+[Zephyr RTOS](https://www.zephyrproject.org/) in power systems at the 
+[LFEnergy Spring Summit](https://events.linuxfoundation.org/lf-energy-spring-summit/):
+ 
+[Video recording](https://youtu.be/SWDM7YgT-pU) 
+
+[Presentation](https://static.sched.com/hosted_files/lfenergyspringsummit2021/9f/Gula%20and%20Jäger%20-%20ODG%20LFEnergy%20Spring%20Summit.pdf)
+:::
+
 ## DC Microgrid
 The Open DC Grid is a microgrid architecture to permit devices to exchange electric power using DC (direct current). The architecture is defined by the [Open DC Grid Standard](./standard), a document than can be freely accessed and used by anyone at no charge.
 The architecture defined by the standard permits devices to be connected using several kinds of link technology but the most commonly used link is an electrical bus operating at a nominal 48 V.

--- a/docs/meetings.md
+++ b/docs/meetings.md
@@ -19,54 +19,67 @@ A note for people using a telephone dial-in connection: you can mute/unmute by p
 Further instructions are available on the Zoom web site:
 [Joining a meeting by phone](https://support.zoom.us/hc/en-us/articles/201362663-Joining-a-meeting-by-phone).
 
-## Content of previous meetings
+## Content of previous meetings (most recent first)
 
-### 2020-01-14 Meeting
-[Meeting recording](https://www.dropbox.com/s/e2ku7i84wlelgb4/2020-01-14-%2311.mp4?dl=0)
+### 2021-04-14 LFEnergy Presentation
 
-[ODG (James Gula) presentation](./MeetingMaterials/20200114MeetingRev04.pdf)
+ODG gave an overview presentation on the project and our use of the 
+[Zephyr RTOS](https://www.zephyrproject.org/) in power systems at the 
+[LFEnergy Spring Summit](https://events.linuxfoundation.org/lf-energy-spring-summit/):
+ 
+[Video recording](https://youtu.be/SWDM7YgT-pU) 
 
-### 2020-02-11 Meeting
-[Meeting recording](https://www.dropbox.com/s/pmdcygflc2buqo4/2020-02-11-%2312.mp4?dl=0)
+[Presentation](https://static.sched.com/hosted_files/lfenergyspringsummit2021/9f/Gula%20and%20Jäger%20-%20ODG%20LFEnergy%20Spring%20Summit.pdf)
 
-[ODG (James Gula) presentation](./MeetingMaterials/20200211MeetingRev02.pdf)
+### 2021-04-13 Meeting
 
-[ODG (Martin Jäger) presentation](./MeetingMaterials/20200211_DC_grid_converter_fundamentals.pdf)
+[Meeting Recording](https://www.dropbox.com/s/i874c2qbdo4o9ur/GMT20210413-140339_Recording_2560x1440.mp4?dl=0)
 
-### 2020-03-10 Meeting
-[Meeting recording](https://www.dropbox.com/s/hk9yqo372q7xrrs/2020-03-10-%2313.mp4?dl=0)
+[ODG (James Gula) presentation](./MeetingMaterials/20210413ODGMeetingRev02.pdf)
 
-[ODG (James Gula) presentation](./MeetingMaterials/20200310MeetingRev03.pdf)
+<a name="OwnTech"></a>[OwnTech (Jean Alinei / Luiz Villa)](./MeetingMaterials/20210413OwnTech.pdf)
 
-[IEEE P2030.10.1 (Rajesh Kunnath) presentation](./MeetingMaterials/20200310MeetingRajesh.pdf)
+### 2021-03-09 Meeting
 
-### 2020-04-14 Meeting
-[Meeting recording](https://www.dropbox.com/s/ei6kba5dq9riofh/2020-04-14-%2315.mp4?dl=0)
+[Meeting Recording](https://www.dropbox.com/s/qvgcbr1n71jmzg5/GMT20210309-150129_Open-DC-Gr_2560x1440.mp4?dl=0)
 
-[ODG (James Gula) presentation](./MeetingMaterials/20200414MeetingRev02.pdf)
+[ODG (James Gula) presentation](./MeetingMaterials/20210309ODGMeetingRev02.pdf)
 
-### 2020-05-12 Meeting
-[Meeting recording](https://www.dropbox.com/s/8md1yetvt52vtzb/2020-05-12-%2316.mp4?dl=0)
+### 2021-02-9 Meeting
 
-[ODG (James Gula) presentation](./MeetingMaterials/20200512MeetingRev02.pdf)
+The February 9 meeting was cancelled.
 
-[New Mexico State (Sijo Augustine) presentation](./MeetingMaterials/20200512MeetingAugustine.pdf)
+### 2021-01-12 Meeting
 
-[ODG (Chris Moller) presentation](./MeetingMaterials/20200512MeetingMoller.pdf)
+[Meeting Recording](https://www.dropbox.com/s/39dhalto1d9w1l7/GMT20210112-150208_Open-DC-Gr_2560x1440.mp4?dl=0)
 
-### 2020-06-09 Meeting
-[Meeting recording](https://www.dropbox.com/s/1wbscf18bo4yz3g/2020-06-09-%2317.mp4?dl=0)
+[ODG (James Gula and Bruce Nordman) presentation](./MeetingMaterials/20210112MeetingRev02.pdf)
 
-[ODG (James Gula) presentation](./MeetingMaterials/20200609MeetingRev01.pdf)
+### 2020-12-08 Meeting
 
-[ODG (Martin Jäger) presentation](./MeetingMaterials/20200609MeetingJager.pdf)
+[Meeting Recording](https://www.dropbox.com/s/sh6ot2vq7wp3g5z/GMT20201208-150138_Open-DC-Gr_2560x1440.mp4?dl=0)
 
-### 2020-07-14 Meeting
-[Meeting recording](https://www.dropbox.com/s/3enew2kqur0qrvo/2020-07-14-%2318.mp4?dl=0)
+[ODG (James Gula) presentation](./MeetingMaterials/20201208MeetingRev02.pdf)
 
-[GOGLA (Garick Lee) presentation](./MeetingMaterials/20200714_GOGLA_slides_for_ODG_meeting.pdf)
+[LFEnergy (Shuli Goodman) presentation](./MeetingMaterials/20201208Goodman_LFEnergy_High_Level_Overview.pdf)
 
-[ODG (James Gula)  presentation](./MeetingMaterials/20200714_Open_DC_Grid_Meeting_Rev_01.pdf)
+### 2020-11-10 Meeting
+
+The November 2020 meeting was cancelled.
+
+### 2020-10-13 Meeting
+[Meeting Recording](https://www.dropbox.com/s/yliy1ovrc9q2sxs/GMT20201013-140155_Open-DC-Gr_2560x1440.mp4?dl=0)
+
+[ODG (James Gula) presentation](./MeetingMaterials/20201013MeetingRev01.pdf)
+
+[ODG (Martin Jäger) presentation](./MeetingMaterials/20201013Jager.pdf)
+
+### 2020-09-08 Meeting
+[Meeting recording](https://www.dropbox.com/s/7kvt9bylijcccpk/GMT20200908-140238_Open-DC-Gr_2560x1440.mp4?dl=0)
+
+[ODG (James Gula) presentation](./MeetingMaterials/20200908MeetingRev01.pdf)
+
+[UW (Joe Decuir) presentation](./MeetingMaterials/20200908Decuir.pdf)
 
 ### 2020-08-11 Meeting
 [Meeting recording](https://www.dropbox.com/s/wil4wa3147l4a0i/GMT20200811-140049_Open-DC-Gr_2560x1440.mp4?dl=0)
@@ -77,52 +90,49 @@ Further instructions are available on the Zoom web site:
 
 [Solaris (Danielle Nedosseikine) presentation](./MeetingMaterials/20200811Solaris.pdf)
 
-### 2020-09-08 Meeting
-[Meeting recording](https://www.dropbox.com/s/7kvt9bylijcccpk/GMT20200908-140238_Open-DC-Gr_2560x1440.mp4?dl=0)
+### 2020-07-14 Meeting
+[Meeting recording](https://www.dropbox.com/s/3enew2kqur0qrvo/2020-07-14-%2318.mp4?dl=0)
 
-[ODG (James Gula) presentation](./MeetingMaterials/20200908MeetingRev01.pdf)
+[GOGLA (Garick Lee) presentation](./MeetingMaterials/20200714_GOGLA_slides_for_ODG_meeting.pdf)
 
-[UW (Joe Decuir) presentation](./MeetingMaterials/20200908Decuir.pdf)
+[ODG (James Gula)  presentation](./MeetingMaterials/20200714_Open_DC_Grid_Meeting_Rev_01.pdf)
 
-### 2020-10-13 Meeting
-[Meeting Recording](https://www.dropbox.com/s/yliy1ovrc9q2sxs/GMT20201013-140155_Open-DC-Gr_2560x1440.mp4?dl=0)
+### 2020-06-09 Meeting
+[Meeting recording](https://www.dropbox.com/s/1wbscf18bo4yz3g/2020-06-09-%2317.mp4?dl=0)
 
-[ODG (James Gula) presentation](./MeetingMaterials/20201013MeetingRev01.pdf)
+[ODG (James Gula) presentation](./MeetingMaterials/20200609MeetingRev01.pdf)
 
-[ODG (Martin Jäger) presentation](./MeetingMaterials/20201013Jager.pdf)
+[ODG (Martin Jäger) presentation](./MeetingMaterials/20200609MeetingJager.pdf)
 
-### 2020-11-10 Meeting
+### 2020-05-12 Meeting
+[Meeting recording](https://www.dropbox.com/s/8md1yetvt52vtzb/2020-05-12-%2316.mp4?dl=0)
 
-The November 2020 meeting was cancelled.
+[ODG (James Gula) presentation](./MeetingMaterials/20200512MeetingRev02.pdf)
 
-### 2020-12-08 Meeting
+[New Mexico State (Sijo Augustine) presentation](./MeetingMaterials/20200512MeetingAugustine.pdf)
 
-[Meeting Recording](https://www.dropbox.com/s/sh6ot2vq7wp3g5z/GMT20201208-150138_Open-DC-Gr_2560x1440.mp4?dl=0)
+[ODG (Chris Moller) presentation](./MeetingMaterials/20200512MeetingMoller.pdf)
 
-[ODG (James Gula) presentation](./MeetingMaterials/20201208MeetingRev02.pdf)
+### 2020-04-14 Meeting
+[Meeting recording](https://www.dropbox.com/s/ei6kba5dq9riofh/2020-04-14-%2315.mp4?dl=0)
 
-[LFEnergy (Shuli Goodman) presentation](./MeetingMaterials/20201208Goodman_LFEnergy_High_Level_Overview.pdf)
+[ODG (James Gula) presentation](./MeetingMaterials/20200414MeetingRev02.pdf)
 
-### 2021-01-12 Meeting
+### 2020-03-10 Meeting
+[Meeting recording](https://www.dropbox.com/s/hk9yqo372q7xrrs/2020-03-10-%2313.mp4?dl=0)
 
-[Meeting Recording](https://www.dropbox.com/s/39dhalto1d9w1l7/GMT20210112-150208_Open-DC-Gr_2560x1440.mp4?dl=0)
+[ODG (James Gula) presentation](./MeetingMaterials/20200310MeetingRev03.pdf)
 
-[ODG (James Gula and Bruce Nordman) presentation](./MeetingMaterials/20210112MeetingRev02.pdf)
+[IEEE P2030.10.1 (Rajesh Kunnath) presentation](./MeetingMaterials/20200310MeetingRajesh.pdf)
 
-### 2021-02-9 Meeting
+### 2020-02-11 Meeting
+[Meeting recording](https://www.dropbox.com/s/pmdcygflc2buqo4/2020-02-11-%2312.mp4?dl=0)
 
-The February 9 meeting was cancelled.
+[ODG (James Gula) presentation](./MeetingMaterials/20200211MeetingRev02.pdf)
 
-### 2021-03-09 Meeting
+[ODG (Martin Jäger) presentation](./MeetingMaterials/20200211_DC_grid_converter_fundamentals.pdf)
 
-[Meeting Recording](https://www.dropbox.com/s/qvgcbr1n71jmzg5/GMT20210309-150129_Open-DC-Gr_2560x1440.mp4?dl=0)
+### 2020-01-14 Meeting
+[Meeting recording](https://www.dropbox.com/s/e2ku7i84wlelgb4/2020-01-14-%2311.mp4?dl=0)
 
-[ODG (James Gula) presentation](./MeetingMaterials/20210309ODGMeetingRev02.pdf)
-
-### 2021-04-13 Meeting
-
-[Meeting Recording](https://www.dropbox.com/s/i874c2qbdo4o9ur/GMT20210413-140339_Recording_2560x1440.mp4?dl=0)
-
-[ODG (James Gula) presentation](./MeetingMaterials/20210413ODGMeetingRev02.pdf)
-
-<a name="OwnTech"></a>[OwnTech (Jean Alinei / Luiz Villa)](./MeetingMaterials/20210413OwnTech.pdf)
+[ODG (James Gula) presentation](./MeetingMaterials/20200114MeetingRev04.pdf)

--- a/docs/participants.md
+++ b/docs/participants.md
@@ -8,12 +8,12 @@ This list gives an overview of people and organizations who are currently active
 
 ### James Gula
 
-Retired engineer interested in improving lives with DC grids and related technology. System architecture lead and primary author of IEEE draft standard [P2030.10 DC Microgrids for Rural and Remote Applications](https://site.ieee.org/sagroups-2030-10/). Cofounder of this open standard project with Martin Jäger.
+<a name="JamesGula"></a>Retired engineer interested in improving lives with DC grids and related technology. System architecture lead and primary author of IEEE draft standard [P2030.10 DC Microgrids for Rural and Remote Applications](https://site.ieee.org/sagroups-2030-10/). Cofounder of this open standard project with Martin Jäger.
 
 E-Mail: <a href="mailto:jlgula@papugh.com" target="_top">jlgula@papugh.com</a>
 
 ### Martin Jäger (Libre Solar)
 
-Engineer and open source enthusiast currently developing DC grids for energy access in Rwanda. He is the founder of the [Libre Solar](https://libre.solar) open hardware project and initiated this open standardization together with Jim Gula.
+<a name="MartinJäger"></a>Engineer and open source enthusiast currently developing DC grids for energy access in Rwanda. He is the founder of the [Libre Solar](https://libre.solar) open hardware project and initiated this open standardization together with Jim Gula.
 
 E-Mail: martin at libre.solar

--- a/docs/references.md
+++ b/docs/references.md
@@ -19,8 +19,14 @@ This section is just getting started, filling more as we have the time and energ
 ## Microgrid Architecture
 [*DC Local Power Distribution with Microgrids and Nanogrid*](https://drive.google.com/open?id=0B8B9XW6B7prlczMzOE1QWHFXNjA). Nordman, B, and K. Christensen, First International Conference on DC Microgrids, Atlanta, GA, June 2015. Bruce Nordman was an early advocate and innovator for the kinds of microgrids this project is working toward. [Bruce's website](http://nordman.lbl.gov/) is a trove of papers, talks and related material.
 
-[*A Simulation of Local Power Distribution Control Strategies*](https://drive.google.com/file/d/0B8B9XW6B7prlRksyQk9TVl9tU3c/view). Nordman, B., K. Spears, A. Kahndkar, and M. Pezzola. 
-Second International Conference on DC Microgrids, Nurnburg, Germany, June 2017 - Contains a more detailed description of the LPD power protocols .
+<a name="LPD"></a>[*A Simulation of Local Power Distribution Control Strategies*](https://drive.google.com/file/d/0B8B9XW6B7prlRksyQk9TVl9tU3c/view). Nordman, B., K. Spears, A. Kahndkar, and M. Pezzola. 
+Second International Conference on DC Microgrids, Nurnburg, Germany, June 2017 - Contains a more detailed description of the LPD power protocols.
+
+<a name="Hyphae"></a>[Hyphae](https://www.lfenergy.org/projects/hyphae/). 
+A project from [Sony CSL](https://www.sonycsl.co.jp/) to define peer-to-peer power distribution in a microgrid. 
+The architecture and software have been offered under open source adopted by [LFEnergy](#LFEnergy).
+The [specification](https://github.com/hyphae/apis-main/blob/master/doc/en/apis-main_specification_en.md)
+and code are available on the [Hyphae GitHub Site](https://github.com/hyphae).
 
 ## Related Microgrid Standards
 <a name="IEEEP2030.10"></a>[IEEE P2030.10 Draft Trial-Use Standard for DC Microgrids for Rural and Remote Electricity Access Applications](https://site.ieee.org/sagroups-2030-10/) Describes the requirements to implement an unmanaged grid operating at a nominal 48V. Includes external wiring recommendations and safety concerns. One of the standards this project is attempting to harmonize with. P2030.10, in turn, is harmonized with [ISO 21780](#ISO21780).
@@ -37,7 +43,7 @@ A special interest group for microgrids under the LFEnergy project.
 operating under the umbrella of the [Linux Foundation](https://www.linuxfoundation.org/).
 
 <a name="MicrogridKnowledge"></a>[Microgrid Knowledge](https://microgridknowledge.com) An online newsletter
-focused on microgrids and distributed energy resources. 
+focused on microgrids and distributed energy resources.
 
 ## Off-Grid Energy Access Organizations and Initiatives
 
@@ -75,6 +81,47 @@ derived from [Lighting Global](#LightingGlobal) testing procedures. Products tha
 
 <a name="Wind Empowerment"></a>[Wind Empowerment](https://windempowerment.org/): Wind Empowerment is an association for the 
 development of locally manufactured small wind turbines for sustainable rural electrification. 
+
+## Microgrid Vendors
+
+Companies currently offering products and services related to Open DC Grid:
+
+<a name="Angaza"></a>[Angaza](https://www.angaza.com/): Makes
+remote management and customer relationship software for off-grid power systems.
+Angaza is based in the US and Kenya and markets its products globally.
+
+<a name="ConnectedEnergy"></a>[Connected Energy](https://connectedenergy.net): Makes
+smart monitoring products for off-grid energy including solar and biogas.
+Connected Energy is based in Scotland and markets its products globally.
+
+<a name="LibreSolar"></a>[Libre Solar](https://libre.solar/): A company founded by 
+Open DC Grid co-founder [Martin Jäger](participants#MartinJäger) that makes PV charge controllers,
+battery management systems and other hardware for the renewable energy and energy access markets. Libre Solar
+offers its designs under open source at its [GitHub site](https://github.com/LibreSolar).
+Libre Solar is based in Germany and collaborates with partners to offer products globally.
+
+<a name="MeshPower"></a>[MeshPower Rwanda](https://www.meshpower.co.rw/): Sells
+solar powered microgrids and smart meters for the energy access markets. Its business model
+is to sell energy as a service that does not require the customer to purchase hardware. 
+It is based in Rwanda and its primary market focus is central Africa.
+MeshPower Rwanda is a subsidiary of [Xpower](#Xpower).
+
+<a name="OkraSolar"></a>[OkraSolar](https://okrasolar.com/): Offers tools and hardware
+for the last mile distribution of power via mesh grids. Okra is based in Cambodia
+and its primary markets are in East Asia including Cambodia and the Philippines.
+
+<a name="Solaris"></a>[Solaris Offgrid](https://www.solarisoffgrid.com/): Provides software
+and services for off-grid vendors particularly tools related to pay-as-you-go (PAYGO) billing.
+Solaris Offgrid is based in London and markets its products globally.
+ 
+<a name="Solshare"></a>[Solshare](https://me-solshare.com/): Interconnects solar home systems
+into smart peer-to-peer microgrids that allows consumers to monetize excess solar energy by
+sharing it with neighbors utilizing mobile money. Solshare is based in Bangladesh
+and its primary markets are in South Asia.
+
+<a name="Xpower"></a>[Xpower](https://www.xpowerinc.com/): A US company focussed on 
+developing technologies which enable distributed utilities across the 
+developing world to provide rural communities with modern services. 
 
 ## Vehicle Electrical Standards and Systems
 
@@ -128,7 +175,11 @@ The US Standard for an AC charging connector. [Wikipedia](https://en.wikipedia.o
 <a name="OpenCharge"></a>[Open Charge Alliance](https://www.openchargealliance.org/) An association of vendors
 promoting the Open Charge Point Protocol - an open standard for EV charging.
 
-## Software Standards and Initiatives Related to ODG
+## Software Standards and Initiatives
+<a name="OpenAPI"></a>[OpenAPI Initiative](https://www.openapis.org/): A standard that
+allows the description of a remote API accessible through HTTP or HTTP-like protocols including 
+[CoAP](#CoAP). The API is described in a schema written in [JSON](#JSON). [Tools](#OpenAPITools) exist to
+translate the schema into client or server source code in many computer languages and frameworks. 
 
 The following items are organized roughly by layer according to the [OSI model](https://en.wikipedia.org/wiki/OSI_model)
 but note that things don't always fall neatly into that model or span multiple layers.
@@ -261,12 +312,112 @@ In some cases these models define a complete API for a device. More commonly a d
 to combine various models like [BinarySwitch](https://oneiota.org/revisions/6149) - a very long-winded
 way to describe an on-off switch.
 
+<a name="OpenADR"></a>[OpenADR](https://www.openadr.org/): An open standard to automate and simplify
+[Demand Response(DR)](https://en.wikipedia.org/wiki/Demand_response), a mechanism by which a utility
+grid can ask power consumers to reduce power consumption to match the supply available to the utility.
+In the context of microgrids, the utility grid would ask the microgrid to reduce its demand
+at the [point of common coupling](https://en.wikipedia.org/wiki/Microgrid#Point_of_common_coupling_%28PCC%29).
+The microgrid would then adjust its internal power flows to minimize consumption from the utility grid.
+
 <a name="ThingSet"></a>[ThingSet](https://libre.solar/thingset/): A transport agnostic protocol for the setting of things
 that encompasses layers 5-7 of the OSI model. It is a client server protocol where the values
 are represented in [JSON](#JSON) for human readability or [CBOR](#CBOR) for machine consumption.
 Information is represented as a tree and can be retrieved via a query that can include an entire branch.
 Modifications use a mechanism similar to iPATCH as defined in [RFC 8132](https://tools.ietf.org/html/rfc8132),
 a potentially multi-valued but idempotent modification of leaf nodes.
+
+## Embedded Systems, Development Tools and Firmware
+
+### Embedded Systems - Microcontrollers
+
+<a name="ArmCortexM"></a>[Arm Cortex-M](https://en.wikipedia.org/wiki/ARM_Cortex-M): A family
+of 32-bit 
+[RISC](https://en.wikipedia.org/wiki/Reduced_instruction_set_computer) 
+processor cores based on designs licensed from
+[Arm](https://en.wikipedia.org/wiki/Arm_Ltd). Microcontrollers based on these cores
+with varying peripherals are available from many vendors include [ST](#STM32),
+[TI](https://www.ti.com/microcontrollers-mcus-processors/processors/arm-based-processors/products.html)
+and others. Firmware for these microcontrollers is commonly compiled using
+the 
+[GNU tool chain](#GNUToolchain).
+
+<a name="STM32"></a>[STM32](https://www.st.com/en/microcontrollers-microprocessors/stm32-32-bit-arm-cortex-mcus.html): 
+A family of 32-bit microcontrollers based on the Arm Cortex -M series of processors.
+These are the microcontrollers most commonly used on ODG demonstration boards.
+A useful way to get started with STM32 is to purchase one of the family of ST demonstration
+boards referred to as 
+[STM32 Nucleo](https://www.st.com/en/evaluation-tools/stm32-nucleo-boards.html).
+These are low-cost and many come with pins that support 
+[Arduino Shields](https://playground.arduino.cc/Main/SimilarBoards/#goShie).
+
+### Tools for Embedded Software
+
+<a name="Docker"></a>[Docker](https://www.docker.com/): A lightweight virtualization tool that allows
+a host computer to execute virtualized images of other platforms. The docker engine is free and available
+for Windows, Mac and Linux. For development, docker supports
+creating an image with all the tools installed with known versions and a known OS
+so a build can be assured of completing, such as
+[zephyrprojectrtos/zephyr-build](https://hub.docker.com/r/zephyrprojectrtos/zephyr-build)
+which is a snapshot of the official Zephyr project build environment.
+
+
+<a name="Eclipse"></a>[Eclipse](https://www.eclipse.org): A free and open source desktop integrated
+development environment (IDE) that supports plugins for a wide variety of specialized tools.
+Typically these plugins can be applied to the 
+[base Eclipse platform](https://www.eclipse.org/downloads/) or as a download
+that has the plugin preinstalled so that the combined environment is ready to run, referred to as
+***packages*** in the Eclipse world.
+Some packages that may be of interest to ODG developers include:
+
+* <a name="EclipseCDT"></a>[Eclipse CDT](https://www.eclipse.org/cdt/): An IDE for C and C++ programming. Includes
+editors, compilers([GCC](#GCC) and [Clang](https://clang.llvm.org/)),
+debuggers([GDB](https://www.gnu.org/software/gdb/) and
+[LLDB](https://lldb.llvm.org/)) and build tools([Make](https://www.gnu.org/software/make/), Eclipse native).
+
+* <a name="EclipseEmbeddedCDT"></a>[Eclipse Embedded CDT](https://projects.eclipse.org/projects/iot.embed-cdt): 
+A more specialized version of [Eclipse CDT](#EclipseCDT) focused on
+[Arm](https://en.wikipedia.org/wiki/ARM_architecture) and
+[RISC-V](https://en.wikipedia.org/wiki/RISC-V) applications. Supports multiple tool chains.
+
+<a name="GNUToolchain"></a>[GNU Toolchain](https://en.wikipedia.org/wiki/GNU_toolchain): 
+A set of open-source programming tools from the
+[GNU Project](https://en.wikipedia.org/wiki/GNU_Project).
+Packages (build-essential) to install the tool chain are available on all flavors of Linux. On Windows
+these tools are typically installed using 
+[mingw-w64](http://mingw-w64.org/doku.php/start). On a Mac, the tool chain can be installed
+with a package manager such as [homebrew](https://brew.sh/).
+The tools include:
+
+* <a name="GCC"></a>[GCC](https://gcc.gnu.org/): A cross-compiler with front ends for C, C++
+and other languages.
+
+* <a name="GDB"></a>[GDB](https://www.gnu.org/software/gdb/): 
+A command line debugger. IDEs such as [Eclipse](#EclipseCDT) integrate GDB to provide a GUI.
+
+* <a name="GNUMake"></a>[GNU Make](https://www.gnu.org/software/make/): 
+A build tool that describes the creation of an executable using dependencies
+to minimize recompilation.
+
+<a name="OpenAPITools"></a>[OpenAPI Tools](https://openapi.tools/): A collection of
+tools to edit [OpenAPI](#OpenAPIß) schemas, generate client or server code and test the schema.
+
+<a name="Platformio"></a>[Platformio](https://platformio.org/): An open source
+tool for developing embedded firmware. It can be run as command line interface (CLI)
+or as an integrated development environment (IDE) operating as an extension to
+[Visual Studio Code](https://code.visualstudio.com/) a free code editor from Microsoft.
+
+<a name="STMCubeIDE"></a>[STM32CubeIDE](https://www.st.com/en/development-tools/stm32cubeide.html): 
+A repackaged version of [Eclipse](#Eclipse) that contains plugins to simplify
+development on the [SMT32](#STM32) processors including a pinout configurator.
+
+### Operating Systems for Embedded Software
+
+<a name="Zephyr"></a>[Zephyr RTOS](https://www.zephyrproject.org/): An open source
+[real time operating system(RTOS)](https://en.wikipedia.org/wiki/Real-time_operating_system) 
+that provides the OS platform for ODG's
+demonstration boards. It's 
+[main repository](https://github.com/zephyrproject-rtos/zephyr) is hosted on GitHub.
+
 
 
 


### PR DESCRIPTION
Home page (readme.md): Added a prominent tip about our LFEnergy presentation.
Participants: Just added anchors to the names to link from other pages.
Meetings: Added a section on the LFEnergy Presentation to give it a permanent home. Reversed the order of the meetings to be most recent first.
References:
1 Added a section of Microgrid vendors that links to the various companies we have dealt with including actual grid vendors like Mesh Power and Solshare. Include Libre.Solar so you might want to edit.
2. Added a new section on Embedded Systems, Tools and Firmware to capture
links to the various tools and things. This might move to the Implementation section eventually but wanted a place that I could reference in emails etc.
3. Added a few new links in various other sections.
Added a few new links in various sections.